### PR TITLE
Add user controller to fix user edits

### DIFF
--- a/ckanext/adfs/plugin.py
+++ b/ckanext/adfs/plugin.py
@@ -10,6 +10,7 @@ import base64
 from validation import validate_saml
 from metadata import get_certificates, get_federation_metadata, get_wsfed
 from extract import get_user_info
+from ckan.config.routing import SubMapper
 
 
 log = logging.getLogger(__name__)
@@ -71,6 +72,11 @@ class ADFSPlugin(plugins.SingletonPlugin):
             'adfs_redirect_uri', '/adfs/signin/',
             controller='ckanext.adfs.plugin:ADFSRedirectController',
             action='login')
+        # Route user edits to a custom contoller
+        with SubMapper(map, controller='ckanext.adfs.user:ADFSUserController') as m:
+            m.connect('/user/edit', action='edit')
+            m.connect('user_edit', '/user/edit/{id:.*}', action='edit',
+                      ckan_icon='cog')
         return map
 
     def after_map(self, map):

--- a/ckanext/adfs/user.py
+++ b/ckanext/adfs/user.py
@@ -30,9 +30,9 @@ unflatten = dictization_functions.unflatten
 
 
 class ADFSUserController(UserController):
-    def _save_edit(self, id, context):
+    def _save_edit(self, user_id, context):
         try:
-            if id in (c.userobj.id, c.userobj.name):
+            if user_id in (c.userobj.id, c.userobj.name):
                 current_user = True
             else:
                 current_user = False
@@ -41,7 +41,7 @@ class ADFSUserController(UserController):
             data_dict = logic.clean_dict(unflatten(
                 logic.tuplize_dict(logic.parse_params(request.params))))
             context['message'] = data_dict.get('log_message', '')
-            data_dict['id'] = id
+            data_dict['id'] = user_id
 
             if data_dict.get('password1') and data_dict.get('password2'):
                 identity = {'login': c.user,
@@ -64,7 +64,7 @@ class ADFSUserController(UserController):
                 set_repoze_user(data_dict['name'])
             h.redirect_to(controller='user', action='read', id=user['name'])
         except NotAuthorized:
-            abort(401, _('Unauthorized to edit user %s') % id)
+            abort(401, _('Unauthorized to edit user %s') % user_id)
         except NotFound, e:
             abort(404, _('User not found'))
         except DataError:
@@ -72,8 +72,8 @@ class ADFSUserController(UserController):
         except ValidationError, e:
             errors = e.error_dict
             error_summary = e.error_summary
-            return self.edit(id, data_dict, errors, error_summary)
+            return self.edit(user_id, data_dict, errors, error_summary)
         except UsernamePasswordError:
             errors = {'oldpassword': [_('Password entered was incorrect')]}
             error_summary = {_('Old Password'): _('incorrect password')}
-            return self.edit(id, data_dict, errors, error_summary)
+            return self.edit(user_id, data_dict, errors, error_summary)

--- a/ckanext/adfs/user.py
+++ b/ckanext/adfs/user.py
@@ -1,0 +1,79 @@
+import ckan.lib.base as base
+import ckan.model as model
+import ckan.lib.helpers as h
+import ckan.authz as authz
+import ckan.logic as logic
+import ckan.lib.navl.dictization_functions as dictization_functions
+import ckan.lib.authenticator as authenticator
+import ckan.plugins as p
+
+from ckan.common import _, c, g, request, response
+from ckan.controllers.user import UserController
+
+try:
+    # CKAN 2.7 and later
+    from ckan.common import config
+except ImportError:
+    # CKAN 2.6 and earlier
+    from pylons import config
+
+
+check_access = logic.check_access
+get_action = logic.get_action
+NotFound = logic.NotFound
+NotAuthorized = logic.NotAuthorized
+ValidationError = logic.ValidationError
+UsernamePasswordError = logic.UsernamePasswordError
+
+DataError = dictization_functions.DataError
+unflatten = dictization_functions.unflatten
+
+
+class ADFSUserController(UserController):
+    def _save_edit(self, id, context):
+        try:
+            if id in (c.userobj.id, c.userobj.name):
+                current_user = True
+            else:
+                current_user = False
+            old_username = c.userobj.name
+
+            data_dict = logic.clean_dict(unflatten(
+                logic.tuplize_dict(logic.parse_params(request.params))))
+            context['message'] = data_dict.get('log_message', '')
+            data_dict['id'] = id
+
+            if data_dict.get('password1') and data_dict.get('password2'):
+                identity = {'login': c.user,
+                            'password': data_dict['old_password']}
+                auth = authenticator.UsernamePasswordAuthenticator()
+
+                if auth.authenticate(request.environ, identity) != c.user:
+                    raise UsernamePasswordError
+
+            # MOAN: Do I really have to do this here?
+            if 'activity_streams_email_notifications' not in data_dict:
+                data_dict['activity_streams_email_notifications'] = False
+
+            user = get_action('user_update')(context, data_dict)
+            h.flash_success(_('Profile updated'))
+
+            if current_user and data_dict['name'] != old_username:
+                # Changing currently logged in user's name.
+                # Update repoze.who cookie to match
+                set_repoze_user(data_dict['name'])
+            h.redirect_to(controller='user', action='read', id=user['name'])
+        except NotAuthorized:
+            abort(401, _('Unauthorized to edit user %s') % id)
+        except NotFound, e:
+            abort(404, _('User not found'))
+        except DataError:
+            abort(400, _(u'Integrity Error'))
+        except ValidationError, e:
+            errors = e.error_dict
+            error_summary = e.error_summary
+            return self.edit(id, data_dict, errors, error_summary)
+        except UsernamePasswordError:
+            errors = {'oldpassword': [_('Password entered was incorrect')]}
+            error_summary = {_('Old Password'): _('incorrect password')}
+            return self.edit(id, data_dict, errors, error_summary)


### PR DESCRIPTION
This PR fixes an issue where users who login through ADFS are unable to update their profile. The issue is a dictionary key error in the CKAN user controller trying to get password1 and password2. 
https://github.com/ckan/ckan/blob/ckan-2.7.2/ckan/controllers/user.py#L353

We'll extend CKAN's user controller with a custom controller using get() to fix the key error.
  