### PR TITLE
Fix ADFS for CNRA

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -38,6 +38,24 @@ If you merely want to test this extension you can take out a free trial at the
 Azure website (although you'll need to provide credit card details to prove
 you're not a bot).
 
+Installation:
+============
+
+Install the required packages::
+
+    sudo apt-get install libxml2 libxml2-dev libxslt1.1 libxslt1-dev openssl libssl-dev swig python-dev
+
+To install ckanext-adfs for development, activate your CKAN virtualenv and do::
+
+    git clone https://github.com/OpenGov-OpenData/ckanext-adfs.git
+    cd ckanext-adfs
+    git checkout cnra
+    python setup.py develop
+    pip install -r requirements.txt
+
+Add ``adfs`` to the ``ckan.plugins`` setting in your CKAN config file (by default the config file is located at
+``/etc/ckan/default/production.ini``).
+
 Configure:
 =========
 

--- a/README.rst
+++ b/README.rst
@@ -58,6 +58,8 @@ In your CKAN's settings.ini file you need to provide two settings in the
 
 * adfs_metadata_url - a URL pointing to a remote file called `FederationMetadata.xml` containing the ADFS_NAMESPACE and adfs_x509 related values. This URL is in the "Federation Metadata Document URL" value in the "Enable Users to Sign On" section of the Azure website (at current time of writing).
 
+* adfs_url_template - a template snippet for the URL that points to the ADFS authentication endpoint (e.g. {}idpinitiatedsignon.aspx?loginToRp={}). This template uses the wsfed endpoint extracted from FederationMetadata.xml and adfs_wtrealm.
+
 *A WORD OF WARNING* Microsoft appears to change its UI in the Azure website
 quite often so you may need to poke around to find the correct settings. It has
 been our experience that their otherwise excellent documentation doesn't

--- a/ckanext/adfs/controller.py
+++ b/ckanext/adfs/controller.py
@@ -50,14 +50,14 @@ class ADFSRedirectController(toolkit.BaseController):
 
         user = model.User.by_name(username)
         if user:
-            if user.get('state') == 'deleted':
+            if not user.is_active():
                 # Deleted user
                 log.error('Unable to login with ADFS, {} was deleted'.format(username))
                 h.flash_error('This CKAN account was deleted and is no longer accessible.')
                 toolkit.redirect_to(controller='user', action='login')
             else:
                 # Existing user
-                log.info('Logging in from ADFS with user: {}'.format(username))
+                log.info('Logging in from ADFS with username: {}'.format(username))
         else:
             # New user, so create a record for them.
             log.info('Creating user from ADFS, username: {}'.format(username))

--- a/ckanext/adfs/controller.py
+++ b/ckanext/adfs/controller.py
@@ -1,0 +1,84 @@
+# encoding: utf-8
+
+import logging
+import ckan.lib.helpers as h
+import ckan.model as model
+import ckan.plugins.toolkit as toolkit
+import pylons
+import uuid
+import base64
+from validation import validate_saml
+from metadata import get_certificates, get_federation_metadata, get_wsfed
+from extract import get_user_info
+
+
+log = logging.getLogger(__name__)
+
+
+class ADFSRedirectController(toolkit.BaseController):
+    """
+    A custom home controller for receiving ADFS authorization responses.
+    """
+
+    def login(self):
+        """
+        Handle eggsmell request from the ADFS redirect_uri.
+        """
+        try:
+            eggsmell = pylons.request.POST.get('wresult')
+            if not eggsmell:
+                request_data = dict(pylons.request.POST)
+                eggsmell = base64.decodestring(request_data['SAMLResponse'])
+        except:
+            log.info('ADFS eggsmell')
+            log.info(dict(pylons.request.POST))
+        # We grab the metadata for each login because due to opaque
+        # bureaucracy and lack of communication the certificates can be
+        # changed. We looked into this and took made the call based upon lack
+        # of user problems and tech being under our control vs the (small
+        # amount of) latency from a network call per login attempt.
+        metadata = get_federation_metadata(pylons.config['adfs_metadata_url'])
+        x509_certificates = get_certificates(metadata)
+        if not validate_saml(eggsmell, x509_certificates):
+            raise ValueError('Invalid signature')
+        username, email, firstname, surname = get_user_info(eggsmell)
+
+        if not email:
+            log.error('Unable to login with ADFS')
+            log.error(eggsmell)
+            raise ValueError('No email returned with ADFS')
+
+        user = model.User.by_name(username)
+        if user:
+            if user.get('state') == 'deleted':
+                # Deleted user
+                log.error('Unable to login with ADFS, {} was deleted'.format(username))
+                h.flash_error('This CKAN account was deleted and is no longer accessible.')
+                toolkit.redirect_to(controller='user', action='login')
+            else:
+                # Existing user
+                log.info('Logging in from ADFS with user: {}'.format(username))
+        else:
+            # New user, so create a record for them.
+            log.info('Creating user from ADFS, username: {}'.format(username))
+            user = model.User(name=username)
+            user.sysadmin = False
+
+        # Update fullname
+        if firstname and surname:
+            user.fullname = firstname + ' ' + surname
+        # Update mail
+        if email:
+            user.email = email
+
+        # Save the user in the database
+        model.Session.add(user)
+        model.Session.commit()
+        model.Session.remove()
+
+        pylons.session['adfs-user'] = username
+        pylons.session['adfs-email'] = email
+        pylons.session.save()
+
+        toolkit.redirect_to(controller='user', action='dashboard', id=email)
+        return

--- a/ckanext/adfs/extract.py
+++ b/ckanext/adfs/extract.py
@@ -26,11 +26,9 @@ def get_user_info(saml):
             firstname = attr[0].text
         elif attr.attrib['Name'].endswith('surname'):
             surname = attr[0].text
-        elif attr.attrib['Name'].endswith('claims/name'):
-            email = attr[0].text
         elif attr.attrib['Name'].endswith('emailaddress'):
             email = attr[0].text
 
-    if email:
-        username = email.split('@', 1)[0].replace('.', '_').lower()
+    username = email
+
     return (username, email, firstname, surname)

--- a/ckanext/adfs/plugin.py
+++ b/ckanext/adfs/plugin.py
@@ -1,21 +1,14 @@
 """
 Plugin for our ADFS
 """
-import logging
 import ckan.plugins as plugins
 import ckan.plugins.toolkit as toolkit
 import pylons
-import uuid
-import base64
-from validation import validate_saml
-from metadata import get_certificates, get_federation_metadata, get_wsfed
-from extract import get_user_info
+from metadata import get_federation_metadata, get_wsfed
 try:
     from ckan.common import config
 except ImportError:
     from pylons import config
-
-log = logging.getLogger(__name__)
 
 
 # Some awful XML munging.
@@ -69,11 +62,16 @@ class ADFSPlugin(plugins.SingletonPlugin):
         :param map: Routes map object
         :returns: Modified version of the map object
         """
-        # Route requests for our WAAD redirect URI to a custom controller.
+        # Route requests for our WAAD redirect URI to a custom controller
         map.connect(
             'adfs_redirect_uri', '/adfs/signin/',
             controller='ckanext.adfs.controller:ADFSRedirectController',
             action='login')
+        # Route password reset requests to a custom controller
+        map.connect(
+            'adfs_request_reset', '/user/reset',
+            controller='ckanext.adfs.controller:ADFSUserController',
+            action='request_reset')
         return map
 
     def after_map(self, map):


### PR DESCRIPTION
[OD-269]
1) Fix username assignment.
Now ADFS usernames are their email address.

2) Deleted ADFS users caused a redirected loop. These users would be redirected to their dashboard, but can't since they are a deleted CKAN user.
Now ADFS users with deleted CKAN accounts will be redirected back to the login page and notified that their account is not accessible.

3) ADFS users can request a CKAN password reset.
Now CKAN password reset requests cannot be made for ADFS users.