### PR TITLE
Add custom user validators

### DIFF
--- a/ckanext/adfs/plugin.py
+++ b/ckanext/adfs/plugin.py
@@ -3,7 +3,9 @@ Plugin for our ADFS
 """
 import ckan.plugins as plugins
 import ckan.plugins.toolkit as toolkit
+import ckan.logic.schema
 import pylons
+from ckanext.adfs import schema
 from metadata import get_federation_metadata, get_wsfed
 try:
     from ckan.common import config
@@ -48,6 +50,9 @@ class ADFSPlugin(plugins.SingletonPlugin):
         """
         Add our templates to CKAN's search path
         """
+        ckan.logic.schema.user_new_form_schema = schema.user_new_form_schema
+        ckan.logic.schema.user_edit_form_schema = schema.user_edit_form_schema
+        ckan.logic.schema.default_update_user_schema = schema.default_update_user_schema
         toolkit.add_template_directory(config_, 'templates')
 
     def get_helpers(self):

--- a/ckanext/adfs/schema.py
+++ b/ckanext/adfs/schema.py
@@ -1,0 +1,73 @@
+from ckan.lib.navl.validators import ignore, ignore_missing, not_empty
+from ckan.logic.validators import (
+    ignore_not_sysadmin,
+    name_validator,
+    user_about_validator,
+    user_both_passwords_entered,
+    user_name_validator,
+    user_password_not_empty,
+    user_password_validator,
+    user_passwords_match
+)
+from ckanext.adfs.validators import (
+    adfs_name_validator,
+    adfs_user_about_validator,
+    adfs_user_name_sanitize
+)
+
+
+def default_user_schema():
+    """
+    Custom schema to validate users
+    """
+    schema = {
+        'id': [ignore_missing, unicode],
+        'name': [not_empty, name_validator, user_name_validator, unicode],
+        'fullname': [ignore_missing, unicode],
+        'password': [user_password_validator, user_password_not_empty, ignore_missing, unicode],
+        'password_hash': [ignore_missing, ignore_not_sysadmin, unicode],
+        'email': [not_empty, unicode],
+        'about': [ignore_missing, user_about_validator, unicode],
+        'created': [ignore],
+        'openid': [ignore_missing],
+        'sysadmin': [ignore_missing, ignore_not_sysadmin],
+        'apikey': [ignore],
+        'reset_key': [ignore],
+        'activity_streams_email_notifications': [ignore_missing],
+        'state': [ignore_missing],
+    }
+    return schema
+
+
+def user_new_form_schema():
+    schema = default_user_schema()
+
+    schema['name'] = [not_empty, adfs_name_validator, user_name_validator, adfs_user_name_sanitize, unicode]
+    schema['fullname'] = [ignore_missing, adfs_user_name_sanitize, unicode]
+    schema['about'] = [ignore_missing, user_about_validator, adfs_user_about_validator, unicode]
+    schema['password1'] = [unicode, user_both_passwords_entered, user_password_validator, user_passwords_match]
+    schema['password2'] = [unicode]
+
+    return schema
+
+
+def user_edit_form_schema():
+    schema = default_user_schema()
+
+    schema['name'] = [ignore_missing, adfs_name_validator, user_name_validator, adfs_user_name_sanitize, unicode]
+    schema['fullname'] = [ignore_missing, adfs_user_name_sanitize, unicode]
+    schema['about'] = [ignore_missing, user_about_validator, adfs_user_about_validator, unicode]
+    schema['password'] = [ignore_missing]
+    schema['password1'] = [ignore_missing, unicode, user_password_validator, user_passwords_match]
+    schema['password2'] = [ignore_missing, unicode]
+
+    return schema
+
+
+def default_update_user_schema():
+    schema = default_user_schema()
+
+    schema['name'] = [ignore_missing, adfs_name_validator, user_name_validator, unicode]
+    schema['password'] = [user_password_validator, ignore_missing, unicode]
+
+    return schema

--- a/ckanext/adfs/validators.py
+++ b/ckanext/adfs/validators.py
@@ -1,0 +1,75 @@
+import re
+from ckan.common import _
+from ckan.model import PACKAGE_NAME_MAX_LENGTH
+from ckan.lib.navl.dictization_functions import Invalid
+
+
+name_match = re.compile('[a-z0-9_\-]*$')
+def adfs_name_validator(value, context):
+    """
+    Custom validator for usernames
+    ADFS users have email addresses as usernames
+    """
+    if not isinstance(value, basestring):
+        raise Invalid(_('Names must be strings'))
+
+    # check basic textual rules
+    if value in ['new', 'edit', 'search']:
+        raise Invalid(_('That name cannot be used'))
+
+    if len(value) < 2:
+        raise Invalid(_('Must be at least %s characters long') % 2)
+    if len(value) > PACKAGE_NAME_MAX_LENGTH:
+        raise Invalid(_('Name must be a maximum of %i characters long') % \
+                      PACKAGE_NAME_MAX_LENGTH)
+
+    # ADFS users can not change their username
+    username = context.get('user')
+    if is_adfs_user(username, context):
+        return username
+
+    if not name_match.match(value):
+        raise Invalid(_('Must be purely lowercase alphanumeric '
+                        '(ascii) characters and these symbols: -_'))
+    return value
+
+
+def adfs_user_name_sanitize(key, data, errors, context):
+    # Non-ADFS users need to sanitize their username
+    username = context.get('user')
+    if not is_adfs_user(username, context):
+        invalid_name = ['admin', 'manage', 'root']
+        value = data[key]
+        if is_input_valid(value) is False:
+            raise Invalid(_('Input Contains Invalid Text'))
+        for invalid_string in invalid_name:
+            if value and re.match(invalid_string, value, re.IGNORECASE):
+                raise Invalid(_('Input Contains Invalid Text'))
+
+
+def adfs_user_about_validator(key, data, errors, context):
+    value = data[key]
+    if is_input_valid(value) is False:
+        raise Invalid(_('Input Contains Invalid Text'))
+
+
+def is_input_valid(input_value):
+    invalid_list = ['hacked', 'hacking', 'hacks', 'hack[^a-zA-Z]+', 'malware', 'virus']
+    for invalid_string in invalid_list:
+        if re.search(invalid_string, input_value, re.IGNORECASE):
+            return False
+    return True
+
+
+def is_adfs_user(username, context):
+    if not username:
+        username = context.get('user')
+    # ADFS users have email addresses as usernames
+    if re.match("[^@]+@[^@]+\.[^@]+", username, re.IGNORECASE):
+        model = context['model']
+        user = model.User.by_name(username)
+        # ADFS users do not have passwords
+        if user:
+            if user.is_active() and not user.password:
+                return True
+    return False


### PR DESCRIPTION
The default CKAN user validators prevent ADFS users from editing their profile. The default validator 'name_validator()' is used to check that usernames contain only '-', '_' and alphanumeric characters. ADFS usernames are email addresses and the characters '@' and '.' cause the usernames to fail validation. This prevents them from editing their profile.

This PR replaces name_validator() with adfs_name_validator(), which checks if a given username belongs to an existing ADFS user. This will allow ADFS users to update their profile.