### PR TITLE
[OD-385] Add profanity filter

### DIFF
--- a/ckanext/adfs/templates/user/list.html
+++ b/ckanext/adfs/templates/user/list.html
@@ -1,0 +1,21 @@
+{% ckan_extends %}
+
+{% block pre_primary %}
+  {% if not c.userobj %}
+    <section class="module-content">
+      <p><a href="/user/login">Login</a> to view user list</p>
+    </section>
+  {% endif %}
+{% endblock %}
+
+{% block primary_content %}
+  {% if c.userobj %}
+    {{ super() }}
+  {% endif %}
+{% endblock %}
+
+{% block secondary_content %}
+  {% if c.userobj %}
+    {{ super() }}
+  {% endif %}
+{% endblock %}

--- a/ckanext/adfs/templates/user/read.html
+++ b/ckanext/adfs/templates/user/read.html
@@ -1,0 +1,7 @@
+{% ckan_extends %}
+
+{% block primary_content_inner %}
+  {% if c.userobj %}
+    {{ super() }}
+  {% endif %}
+{% endblock %}

--- a/ckanext/adfs/templates/user/read_base.html
+++ b/ckanext/adfs/templates/user/read_base.html
@@ -1,0 +1,21 @@
+{% ckan_extends %}
+
+{% block pre_primary %}
+  {% if not c.userobj %}
+    <section class="module-content">
+      <p><a href="/user/login">Login</a> to view user profile</p>
+    </section>
+  {% endif %}
+{% endblock %}
+
+{% block content_primary_nav %}
+  {% if c.userobj %}
+    {{ super() }}
+  {% endif %}
+{% endblock %}
+
+{% block secondary_content %}
+  {% if c.userobj %}
+    {{ super() }}
+  {% endif %}
+{% endblock %}

--- a/ckanext/adfs/validators.py
+++ b/ckanext/adfs/validators.py
@@ -2,6 +2,7 @@ import re
 from ckan.common import _
 from ckan.model import PACKAGE_NAME_MAX_LENGTH
 from ckan.lib.navl.dictization_functions import Invalid
+from profanityfilter import ProfanityFilter
 
 
 name_match = re.compile('[a-z0-9_\-]*$')
@@ -55,9 +56,13 @@ def adfs_user_about_validator(key, data, errors, context):
 
 def is_input_valid(input_value):
     invalid_list = ['hacked', 'hacking', 'hacks', 'hack[^a-zA-Z]+', 'malware', 'virus']
+    pf = ProfanityFilter()
+
     for invalid_string in invalid_list:
         if re.search(invalid_string, input_value, re.IGNORECASE):
             return False
+    if not pf.is_clean(input_value):
+        return False
     return True
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 lxml
 m2crypto
 mock
+profanityfilter


### PR DESCRIPTION
[OD-385](https://opengovinc.atlassian.net/browse/OD-385) Add profanity filter to ckanext-adfs

Add profanity filter for user profiles to ckanext-adfs extension. Hide user profiles and user list page to discourage spam.

Test Procedures
- Install the PR
`sudo apt-get install libxml2 libxml2-dev libxslt1.1 libxslt1-dev openssl libssl-dev swig python-dev`
`git clone https://github.com/OpenGov-OpenData/ckanext-adfs`
`cd ckanext-adfs`
`git checkout cnra-profanity-filter`
`pip install -r requirements.txt`
`python setup.py develop`
- Add adfs to plugins in config ini file
- Visit a user profile page when not logged in and logged in (eg: /user/john_smith)
- Visit the user list page when not logged in and logged in (eg: /user)
- Edit user profile with profanity