### PR TITLE
[OD-843] Generalize File Based Federation Metadata Location

### DIFF
--- a/ckanext/adfs/metadata.py
+++ b/ckanext/adfs/metadata.py
@@ -36,9 +36,12 @@ def get_certificates(metadata):
 def get_federation_metadata(url):
     """
     Grabs the XML from the specified endpoint url.
+
+    This function will check is the url starts with a '/' indicating that it is an
+    absoulte path on the file system.  Otherwise it assumes that it is a URL endpoint.
     """
-    if url.startswith('/usr/lib/ckan/default/src/'):
-        fh = open('/usr/lib/ckan/default/src/ckanext-adfs/ckanext/adfs/FederationMetadata.xml', 'r')
+    if url.startswith('/'):
+        fh = open(url, 'r')
         return fh.read().replace(u'\ufeff', '')
     else:
         response = requests.get(url)
@@ -46,7 +49,6 @@ def get_federation_metadata(url):
             return response.text.replace(u'\ufeff', '')
         else:
             raise ValueError('Metadata response: {}'.format(response.status_code))
-
 
 def get_wsfed(metadata):
     """


### PR DESCRIPTION
On Kubernetes we do not have the path of extensions in the same location as exists on the ec2 machine which causes a discrepancy between the FederationMetadata.xml absolute path on each system.

On ec2 it is `/usr/lib/ckan/default/src/ckanext-adfs/ckanext/adfs/FederationMetadata.xml`
On k8s it is `/src/ckanext-adfs/ckanext/adfs/FederationMetadata.xml`

This PR determines if the "url" is an absolute path by checking for "/" and will use any absolute path so works no matter where the `FederationMetadata.xml` is on the file system.