### PR TITLE
[PERF-66] Fix user identity

### DIFF
--- a/ckanext/adfs/controller.py
+++ b/ckanext/adfs/controller.py
@@ -89,8 +89,20 @@ class ADFSRedirectController(toolkit.BaseController):
         pylons.session['adfs-email'] = email
         pylons.session.save()
 
+        environ = toolkit.request.environ
+        rememberer = self._get_rememberer(environ)
+        identity = {'repoze.who.userid': username}
+        headers = rememberer.remember(environ, identity)
+        for header, value in headers:
+            toolkit.response.headers.add(header, value)
+
         toolkit.redirect_to(controller='user', action='dashboard', id=email)
         return
+
+
+    def _get_rememberer(self, environ):
+        plugins = environ.get('repoze.who.plugins', {})
+        return plugins.get('auth_tkt')
 
 
 class ADFSUserController(UserController):

--- a/ckanext/adfs/controller.py
+++ b/ckanext/adfs/controller.py
@@ -4,7 +4,6 @@ import logging
 import ckan.lib.helpers as h
 import ckan.model as model
 import ckan.plugins.toolkit as toolkit
-import pylons
 import base64
 from validation import validate_saml
 from metadata import get_certificates, get_federation_metadata
@@ -12,7 +11,7 @@ from extract import get_user_info
 import ckan.lib.base as base
 import ckan.logic as logic
 import ckan.lib.mailer as mailer
-from ckan.common import _, c, request
+from ckan.common import _, c, request, session
 from ckan.controllers.user import UserController
 
 
@@ -34,19 +33,19 @@ class ADFSRedirectController(toolkit.BaseController):
         Handle eggsmell request from the ADFS redirect_uri.
         """
         try:
-            eggsmell = pylons.request.POST.get('wresult')
+            eggsmell = toolkit.request.POST.get('wresult')
             if not eggsmell:
-                request_data = dict(pylons.request.POST)
+                request_data = dict(toolkit.request.POST)
                 eggsmell = base64.decodestring(request_data['SAMLResponse'])
         except:
             log.info('ADFS eggsmell')
-            log.info(dict(pylons.request.POST))
+            log.info(dict(toolkit.request.POST))
         # We grab the metadata for each login because due to opaque
         # bureaucracy and lack of communication the certificates can be
         # changed. We looked into this and took made the call based upon lack
         # of user problems and tech being under our control vs the (small
         # amount of) latency from a network call per login attempt.
-        metadata = get_federation_metadata(pylons.config['adfs_metadata_url'])
+        metadata = get_federation_metadata(toolkit.config['adfs_metadata_url'])
         x509_certificates = get_certificates(metadata)
         if not validate_saml(eggsmell, x509_certificates):
             raise ValueError('Invalid signature')
@@ -85,24 +84,20 @@ class ADFSRedirectController(toolkit.BaseController):
         model.Session.commit()
         model.Session.remove()
 
-        pylons.session['adfs-user'] = username
-        pylons.session['adfs-email'] = email
-        pylons.session.save()
+        session['adfs-user'] = username
+        session['adfs-email'] = email
+        session.save()
 
-        environ = toolkit.request.environ
-        rememberer = self._get_rememberer(environ)
-        identity = {'repoze.who.userid': username}
-        headers = rememberer.remember(environ, identity)
-        for header, value in headers:
-            toolkit.response.headers.add(header, value)
+        '''Set the repoze.who cookie to match a given user_id'''
+        if u'repoze.who.plugins' in toolkit.request.environ:
+            rememberer = toolkit.request.environ[u'repoze.who.plugins'][u'friendlyform']
+            identity = {u'repoze.who.userid': username}
+            headers = rememberer.remember(toolkit.request.environ, identity)
+            for header, value in headers:
+                toolkit.response.headers.add(header, value)
 
         toolkit.redirect_to(controller='user', action='dashboard', id=email)
         return
-
-
-    def _get_rememberer(self, environ):
-        plugins = environ.get('repoze.who.plugins', {})
-        return plugins.get('auth_tkt')
 
 
 class ADFSUserController(UserController):

--- a/ckanext/adfs/plugin.py
+++ b/ckanext/adfs/plugin.py
@@ -4,7 +4,7 @@ Plugin for our ADFS
 import ckan.plugins as plugins
 import ckan.plugins.toolkit as toolkit
 import ckan.logic.schema
-import pylons
+from ckan.common import session
 from ckanext.adfs import schema
 from metadata import get_federation_metadata, get_wsfed
 try:
@@ -34,7 +34,7 @@ def adfs_authentication_endpoint():
 
 
 def is_adfs_user():
-    return pylons.session.get('adfs-user')
+    return session.get('adfs-user')
 
 
 class ADFSPlugin(plugins.SingletonPlugin):
@@ -93,7 +93,7 @@ class ADFSPlugin(plugins.SingletonPlugin):
         """
         Called to identify the user.
         """
-        user = pylons.session.get('adfs-user')
+        user = session.get('adfs-user')
 
         environ = toolkit.request.environ
         if user is None and 'repoze.who.identity' in environ:
@@ -112,12 +112,12 @@ class ADFSPlugin(plugins.SingletonPlugin):
         """
         Called at logout.
         """
-        keys_to_delete = [key for key in pylons.session
+        keys_to_delete = [key for key in session
                           if key.startswith('adfs')]
         if keys_to_delete:
             for key in keys_to_delete:
-                del pylons.session[key]
-            pylons.session.save()
+                del session[key]
+            session.save()
 
     def abort(self, status_code, detail, headers, comment):
         """

--- a/ckanext/adfs/plugin.py
+++ b/ckanext/adfs/plugin.py
@@ -94,6 +94,11 @@ class ADFSPlugin(plugins.SingletonPlugin):
         Called to identify the user.
         """
         user = pylons.session.get('adfs-user')
+
+        environ = toolkit.request.environ
+        if user is None and 'repoze.who.identity' in environ:
+            user = environ['repoze.who.identity']['repoze.who.userid']
+
         if user:
             toolkit.c.user = user
 

--- a/ckanext/adfs/plugin.py
+++ b/ckanext/adfs/plugin.py
@@ -92,15 +92,13 @@ class ADFSPlugin(plugins.SingletonPlugin):
     def identify(self):
         """
         Called to identify the user.
+        Get user from repoze.who cookie.
         """
-        user = session.get('adfs-user')
-
         environ = toolkit.request.environ
-        if user is None and 'repoze.who.identity' in environ:
+        user = None
+        if 'repoze.who.identity' in environ:
             user = environ['repoze.who.identity']['repoze.who.userid']
-
-        if user:
-            toolkit.c.user = user
+        toolkit.c.user = user
 
     def login(self):
         """


### PR DESCRIPTION
<!--- Title Link to Jira Ticket - UPDATE WITH YOUR TICKET TAG in name and url --->
## [TICKET](https://opengovinc.atlassian.net/browse/PERF-66)

## Description
<!--- Describe these changes in detail --->
This PR updates the ADFS extension to remove direct use of pylons.
This is done with the following changes:
- Replace `pylons.session` with common session object (`from ckan.common import session`)
- Replace `pylons.config` with `plugins.toolkit.config`
- Replace `pylons.request` with `plugins.toolkit.request `


It also adds logic to store user id in a `repoze.who` cookie.
The code is copied from [ckan/views/user.py](https://github.com/ckan/ckan/blob/394d80b904c9e1a33079971e038a3bd2edbb66e5/ckan/views/user.py#L38-L43)
```
u'''Set the repoze.who cookie to match a given user_id'''
if u'repoze.who.plugins' in request.environ:
    rememberer = request.environ[u'repoze.who.plugins'][u'friendlyform']
    identity = {u'repoze.who.userid': user_id}
    resp.headers.extend(rememberer.remember(request.environ, identity))
```

We later use the `repoze.who` cookie to identify the user. This logic is also used in [ckanext-oauth2](https://github.com/conwetlab/ckanext-oauth2/blob/dbeef5a7ea8aec470f6ac63edd6af06a78a1f898/ckanext/oauth2/plugin.py#L153-L154)
```
if user_name is None and 'repoze.who.identity' in environ:
    user_name = environ['repoze.who.identity']['repoze.who.userid']
```