### PR TITLE
Handle connection when getting federation metadata

### DIFF
--- a/ckanext/adfs/metadata.py
+++ b/ckanext/adfs/metadata.py
@@ -37,11 +37,15 @@ def get_federation_metadata(url):
     """
     Grabs the XML from the specified endpoint url.
     """
-    response = requests.get(url)
-    if response.status_code < 400:
-        return response.content
-    else:
-        raise ValueError('Metadata response: {}'.format(response.status_code))
+    try:
+        response = requests.get(url, timeout=30)
+        if response.status_code < 400:
+            return response.content
+        else:
+            raise ValueError('Metadata response: {}'.format(response.status_code))
+    except Exception as ex:
+        log.error('Error occurred while getting federation metadata from: {}'.format(url))
+        log.exception(ex)
 
 
 def get_wsfed(metadata):

--- a/ckanext/adfs/plugin.py
+++ b/ckanext/adfs/plugin.py
@@ -31,7 +31,7 @@ AUTH_URL_TEMPLATE = toolkit.config.get('adfs_url_template', '{}?wa=wsignin1.0&wr
 
 
 if not (WSFED_ENDPOINT):
-    raise ValueError('Unable to read WSFED_ENDPOINT values for ADFS plugin.')
+    log.error('Unable to read WSFED_ENDPOINT values for ADFS plugin.')
 
 
 def adfs_organization_name():

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 ckantoolkit>=0.0.7
 lxml
-m2crypto==0.39.0
+m2crypto==0.45.1
 mock
 profanityfilter


### PR DESCRIPTION
# Description
Add timeout to get requests and improve error handling to prevent errors when getting ADFS federation metadata from external endpoints. This will prevent the CKAN server from failing to start.